### PR TITLE
Add skeleton for load_data pipeline

### DIFF
--- a/kedro-databricks-bootcamp/02_databricks/rocketfuel/notebooks/02_2-Kedro-on-Databricks-part-2.ipynb
+++ b/kedro-databricks-bootcamp/02_databricks/rocketfuel/notebooks/02_2-Kedro-on-Databricks-part-2.ipynb
@@ -248,7 +248,7 @@
     "\n",
     "Codify the logic of the dummy `load_data` pipeline inside the project and run it locally through `databricks-connect`. For that:\n",
     "\n",
-    "- Create the pipeline in your local development environment.\n",
+    "- Add the necessary nodes to the `load_data` pipeline.\n",
     "- Run ```%reload_kedro``` to reload the Kedro project.\n",
     "- Try to execute the `load_data` pipeline from the VS Code notebook.\n",
     "- Iterate until it works."

--- a/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/__init__.py
+++ b/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'load_data'
+generated using Kedro 0.19.10
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/nodes.py
+++ b/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/nodes.py
@@ -1,0 +1,21 @@
+"""
+This is a boilerplate pipeline 'load_data'
+generated using Kedro 0.19.10
+"""
+
+import pandas as pd
+from pyspark.sql import DataFrame
+from pyspark.sql import SparkSession
+
+from kedro_datasets._utils.spark_utils import get_spark
+
+
+### Your code goes here
+# def my_method(): ....
+
+
+# To be used for the shuttles dataset
+def spark_from_pandas(df: pd.DataFrame) -> DataFrame:
+    """Convert a Pandas DataFrame to a Spark DataFrame."""
+    _spark_session = get_spark()
+    return _spark_session.createDataFrame(df)

--- a/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/pipeline.py
+++ b/kedro-databricks-bootcamp/02_databricks/rocketfuel/src/rocketfuel/pipelines/load_data/pipeline.py
@@ -1,0 +1,33 @@
+"""
+This is a boilerplate pipeline 'load_data'
+generated using Kedro 0.19.10
+"""
+
+from kedro.pipeline import node, Pipeline, pipeline  # noqa
+from .nodes import spark_from_pandas
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            # Your code goes here
+            # node(
+            #     func=...,
+            #     inputs=...,
+            #     outputs=...,
+            #     name=...,
+            # ),
+            # node(
+            #     func=...,
+            #     inputs=...,
+            #     outputs=...,
+            #     name=...,
+            # ),
+            node(
+                func=spark_from_pandas,
+                inputs="shuttles_raw",
+                outputs="shuttles",
+                name="shuttles_load_node",
+            ),
+        ]
+    )


### PR DESCRIPTION
We're not asking participants to write the code for the `shuttles` dataset anymore, so I thought it made sense to add some skeleton code for the `load_data` pipeline which contains the logic for shuttles and some placeholders for the other code so it's clear what they need to do.