### PR TITLE
Remove Opik TEMP workarounds

### DIFF
--- a/kedro-agentic-workflows/conf/base/credentials.yml.template
+++ b/kedro-agentic-workflows/conf/base/credentials.yml.template
@@ -24,18 +24,9 @@ langfuse_credentials:
   endpoint: "https://cloud.langfuse.com/api/public/otel/v1/traces"
 
 # --- Opik (used when --env opik) ---
-# The autogen block reuses opik_credentials via a YAML anchor (`<<: *opik_creds`)
-# so the shared keys live in one place; only `endpoint` diverges.
-opik_credentials: &opik_creds
+# `endpoint` is only needed for autogen mode (the OTLP exporter).
+opik_credentials:
   api_key: "<opik-api-key>"
   workspace: "<opik-workspace>"
   project_name: "<opik-project-name>"
-
-# TEMP: isolates `endpoint` so it doesn't reach the Opik(**credentials) call in
-# opik.PromptDataset/EvaluationDataset (errors on 9.4.0). Fixed by
-# kedro-plugins#1416, once a kedro-datasets release > 9.4.0 ships it,
-# move `endpoint` into opik_credentials above, delete this block, and repoint
-# conf/opik/catalog_genai_config.yml's autogen_tracer to opik_credentials.
-opik_credentials_autogen:
-  <<: *opik_creds
   endpoint: "https://www.comet.com/opik/api/v1/private/otel/v1/traces"

--- a/kedro-agentic-workflows/conf/opik/catalog_genai_config.yml
+++ b/kedro-agentic-workflows/conf/opik/catalog_genai_config.yml
@@ -17,17 +17,8 @@ intent_tracer:
   type: kedro_datasets_experimental.opik.TraceDataset
   credentials: opik_credentials
   mode: langchain           # returns an OpikTracer callback used in session_config
-  # TEMP: on 9.4.0, credentials.project_name isn't forwarded to OpikTracer in
-  # langchain mode, so set it here. Fixed by kedro-plugins#1422 drop
-  # this line once a kedro-datasets release > 9.4.0 ships it.
-  project_name: kedro-agentic-test
 
-# TEMP: separate creds block so `endpoint` doesn't reach the Opik(**credentials)
-# call in opik.PromptDataset/EvaluationDataset (errors on 9.4.0). Fixed by
-# kedro-plugins#1416 once a kedro-datasets release > 9.4.0 ships it,
-# point `credentials` back to opik_credentials and drop opik_credentials_autogen
-# from credentials.yml.template.
 autogen_tracer:
   type: kedro_datasets_experimental.opik.TraceDataset
-  credentials: opik_credentials_autogen
+  credentials: opik_credentials
   mode: autogen             # returns an OpenTelemetry Tracer (start_as_current_span)


### PR DESCRIPTION
# Description

`kedro-datasets 9.5.0` shipped [#1416](https://github.com/kedro-org/kedro-plugins/pull/1416) (tolerate extra credentials) and [#1422](https://github.com/kedro-org/kedro-plugins/pull/1422) (forward project_name in langchain mode), so the two TEMP workarounds from the reorg are no longer needed: dropped the `intent_tracer project_name` override and the separate `opik_credentials_autogen` block (merged endpoint back into opik_credentials). Verified end-to-end on 9.5.0 Opik langchain traces route via `opik_credentials.project_name`, and AutoGen runs with the shared block.